### PR TITLE
fix: typos, repay with wrapped sol, withdraw overpay

### DIFF
--- a/src/actions/liquidate.tsx
+++ b/src/actions/liquidate.tsx
@@ -28,7 +28,7 @@ export const liquidate = async (
   withdrawReserve: ParsedAccount<LendingReserve>
 ) => {
   notify({
-    message: 'Repaing funds...',
+    message: 'Repaying funds...',
     description: 'Please review transactions to approve.',
     type: 'warn',
   });

--- a/src/components/ReserveStatus/index.tsx
+++ b/src/components/ReserveStatus/index.tsx
@@ -106,7 +106,7 @@ export const ReserveStatus = (props: {
           </Col>
           <Col span={6}>
             <Statistic
-              title={LABELS.LIQUIDATION_THREASHOLD}
+              title={LABELS.LIQUIDATION_THRESHOLD}
               className="small-statisitc"
               value={liquidationThreshold}
               precision={2}

--- a/src/components/ReserveUtilizationChart/index.tsx
+++ b/src/components/ReserveUtilizationChart/index.tsx
@@ -22,7 +22,8 @@ export const ReserveUtilizationChart = (props: { reserve: LendingReserve }) => {
     [props.reserve, liquidityMint]
   );
 
-  const percent = (availableLiquidity * 100) / (availableLiquidity + totalBorrows);
+  const totalSupply = availableLiquidity + totalBorrows;
+  const percent = 100 * totalBorrows / totalSupply;
 
   return (
     <WaterWave

--- a/src/components/WithdrawInput/index.tsx
+++ b/src/components/WithdrawInput/index.tsx
@@ -59,14 +59,15 @@ export const WithdrawInput = (props: {
 
     (async () => {
       try {
-        await withdraw(
-          fromAccounts[0],
-          type === InputType.Percent
+        const withdrawAmount = Math.min(type === InputType.Percent
             ? (pct * collateralBalanceLamports) / 100
             : Math.ceil(
                 collateralBalanceLamports *
                   (parseFloat(value) / collateralBalanceInLiquidity)
-              ),
+              ), collateralBalanceLamports);
+        await withdraw(
+          fromAccounts[0],
+          withdrawAmount,
           reserve,
           address,
           connection,

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -53,7 +53,7 @@ export const LABELS = {
   TABLE_TITLE_MARKET_SIZE: "Market Size",
   TABLE_TITLE_ACTION: "Action",
   MAX_LTV: "Maximum LTV",
-  LIQUIDATION_THREASHOLD: "Liquidation threashold",
+  LIQUIDATION_THRESHOLD: "Liquidation threshold",
   LIQUIDATION_PENALTY: "Liquidation penalty",
   TABLE_TITLE_MAX_BORROW: "Available for you",
   DASHBOARD_TITLE_LOANS: "Loans",


### PR DESCRIPTION
#### Changes
- Fix typos
- Fix repays with wrapped sol (if the richest SOL account was a native SOL account, the repay flow did not wrap properly)
- Fix withdraws (collateral calculation was too high, clamped it to current balance)