### PR TITLE
Instruction APIs and docs should match corresponding SPL instructions

### DIFF
--- a/src/actions/deposit.tsx
+++ b/src/actions/deposit.tsx
@@ -106,12 +106,12 @@ export const deposit = async (
         amountLamports,
         fromAccount,
         toAccount,
+        reserveAddress,
+        reserve.liquiditySupply,
+        reserve.collateralMint,
         reserve.lendingMarket,
         authority,
         transferAuthority.publicKey,
-        reserveAddress,
-        reserve.liquiditySupply,
-        reserve.collateralMint
       )
     );
   } else {

--- a/src/models/lending/borrow.ts
+++ b/src/models/lending/borrow.ts
@@ -23,19 +23,22 @@ export enum BorrowAmountType {
 ///   1. `[writable]` Destination liquidity token account, minted by borrow reserve liquidity mint
 ///   2. `[]` Deposit reserve account.
 ///   3. `[writable]` Deposit reserve collateral supply SPL Token account
-///   4. `[writable]` Borrow reserve account.
-///   5. `[writable]` Borrow reserve liquidity supply SPL Token account
-///   6. `[writable]` Obligation
-///   7. `[writable]` Obligation token mint
-///   8. `[writable]` Obligation token output
-///   8 `[]` Lending market account.
-///   10 `[]` Derived lending market authority.
-///   11 `[]` User transfer authority ($authority).
-///   12 `[]` Dex market
-///   13 `[]` Dex market order book side
-///   14 `[]` Temporary memory
-///   15 `[]` Clock sysvar
-///   16 '[]` Token program id
+///   4. `[writable]` Deposit reserve collateral fee receiver account.
+///                     Must be the fee account specified at InitReserve.
+///   5. `[writable]` Borrow reserve account.
+///   6. `[writable]` Borrow reserve liquidity supply SPL Token account
+///   7. `[writable]` Obligation
+///   8. `[writable]` Obligation token mint
+///   9. `[writable]` Obligation token output
+///   10 `[]` Lending market account.
+///   11 `[]` Derived lending market authority.
+///   12 `[]` User transfer authority ($authority).
+///   13 `[]` Dex market
+///   14 `[]` Dex market order book side
+///   15 `[]` Temporary memory
+///   16 `[]` Clock sysvar
+///   17 '[]` Token program id
+///   18 `[optional, writable]` Deposit reserve collateral host fee receiver account.
 export const borrowInstruction = (
   amount: number | BN,
   amountType: BorrowAmountType,

--- a/src/models/lending/borrow.ts
+++ b/src/models/lending/borrow.ts
@@ -42,29 +42,23 @@ export enum BorrowAmountType {
 export const borrowInstruction = (
   amount: number | BN,
   amountType: BorrowAmountType,
-  from: PublicKey, // Collateral input SPL Token account. $authority can transfer $collateralAmount
-  to: PublicKey, // Liquidity output SPL Token account,
+  from: PublicKey,
+  to: PublicKey,
   depositReserve: PublicKey,
   depositReserveCollateralSupply: PublicKey,
   ownerFeeReceiver: PublicKey,
-
   borrowReserve: PublicKey,
   borrowReserveLiquiditySupply: PublicKey,
-
   obligation: PublicKey,
   obligationMint: PublicKey,
   obligationTokenOutput: PublicKey,
-
   lendingMarket: PublicKey,
   lendingMarketAuthority: PublicKey,
   transferAuthority: PublicKey,
-
   dexMarket: PublicKey,
   dexOrderBookSide: PublicKey,
-
   memory: PublicKey,
-
-  hostFeeReceiver?: PublicKey
+  hostFeeReceiver?: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),
@@ -92,7 +86,6 @@ export const borrowInstruction = (
       isWritable: true,
     },
     { pubkey: ownerFeeReceiver, isSigner: false, isWritable: true },
-
     { pubkey: borrowReserve, isSigner: false, isWritable: true },
     {
       pubkey: borrowReserveLiquiditySupply,
@@ -102,11 +95,9 @@ export const borrowInstruction = (
     { pubkey: obligation, isSigner: false, isWritable: true },
     { pubkey: obligationMint, isSigner: false, isWritable: true },
     { pubkey: obligationTokenOutput, isSigner: false, isWritable: true },
-
     { pubkey: lendingMarket, isSigner: false, isWritable: false },
     { pubkey: lendingMarketAuthority, isSigner: false, isWritable: false },
     { pubkey: transferAuthority, isSigner: true, isWritable: false },
-
     { pubkey: dexMarket, isSigner: false, isWritable: false },
     { pubkey: dexOrderBookSide, isSigner: false, isWritable: false },
     { pubkey: memory, isSigner: false, isWritable: false },

--- a/src/models/lending/deposit.ts
+++ b/src/models/lending/deposit.ts
@@ -28,12 +28,12 @@ export const depositInstruction = (
   liquidityAmount: number | BN,
   from: PublicKey, // Liquidity input SPL Token account. $authority can transfer $liquidity_amount
   to: PublicKey, // Collateral output SPL Token account,
+  reserveAccount: PublicKey,
+  reserveSupply: PublicKey,
+  collateralMint: PublicKey,
   lendingMarket: PublicKey,
   reserveAuthority: PublicKey,
   transferAuthority: PublicKey,
-  reserveAccount: PublicKey,
-  reserveSupply: PublicKey,
-  collateralMint: PublicKey
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),

--- a/src/models/lending/deposit.ts
+++ b/src/models/lending/deposit.ts
@@ -26,8 +26,8 @@ import { calculateUtilizationRatio, LendingReserve } from "./reserve";
 ///   9. '[]` Token program id
 export const depositInstruction = (
   liquidityAmount: number | BN,
-  from: PublicKey, // Liquidity input SPL Token account. $authority can transfer $liquidity_amount
-  to: PublicKey, // Collateral output SPL Token account,
+  from: PublicKey,
+  to: PublicKey,
   reserveAccount: PublicKey,
   reserveSupply: PublicKey,
   collateralMint: PublicKey,

--- a/src/models/lending/liquidate.ts
+++ b/src/models/lending/liquidate.ts
@@ -14,9 +14,9 @@ import { TOKEN_PROGRAM_ID, LENDING_PROGRAM_ID } from "../../utils/ids";
 ///   0. `[writable]` Source liquidity token account, minted by repay reserve liquidity mint
 ///                     $authority can transfer $collateral_amount
 ///   1. `[writable]` Destination collateral token account, minted by withdraw reserve collateral mint
-///   2. `[]` Repay reserve account.
+///   2. `[writable]` Repay reserve account.
 ///   3. `[writable]` Repay reserve liquidity supply SPL Token account
-///   4. `[writable]` Withdraw reserve account.
+///   4. `[]` Withdraw reserve account.
 ///   5. `[writable]` Withdraw reserve collateral supply SPL Token account
 ///   6. `[writable]` Obligation - initialized
 ///   7. `[]` Lending market account.

--- a/src/models/lending/liquidate.ts
+++ b/src/models/lending/liquidate.ts
@@ -29,8 +29,8 @@ import { TOKEN_PROGRAM_ID, LENDING_PROGRAM_ID } from "../../utils/ids";
 ///   14 `[]` Token program id
 export const liquidateInstruction = (
   liquidityAmount: number | BN,
-  from: PublicKey, // Liquidity input SPL Token account. $authority can transfer $liquidity_amount
-  to: PublicKey, // Collateral output SPL Token account,
+  from: PublicKey,
+  to: PublicKey,
   repayReserveAccount: PublicKey,
   repayReserveLiquiditySupply: PublicKey,
   withdrawReserve: PublicKey,
@@ -41,7 +41,7 @@ export const liquidateInstruction = (
   transferAuthority: PublicKey,
   dexMarket: PublicKey,
   dexOrderBookSide: PublicKey,
-  memory: PublicKey
+  memory: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),
@@ -60,28 +60,21 @@ export const liquidateInstruction = (
   const keys = [
     { pubkey: from, isSigner: false, isWritable: true },
     { pubkey: to, isSigner: false, isWritable: true },
-
     { pubkey: repayReserveAccount, isSigner: false, isWritable: true },
     { pubkey: repayReserveLiquiditySupply, isSigner: false, isWritable: true },
-
     { pubkey: withdrawReserve, isSigner: false, isWritable: false },
     {
       pubkey: withdrawReserveCollateralSupply,
       isSigner: false,
       isWritable: true,
     },
-
     { pubkey: obligation, isSigner: false, isWritable: true },
-
     { pubkey: lendingMarket, isSigner: false, isWritable: false },
     { pubkey: authority, isSigner: false, isWritable: false },
     { pubkey: transferAuthority, isSigner: true, isWritable: false },
-
     { pubkey: dexMarket, isSigner: false, isWritable: false },
     { pubkey: dexOrderBookSide, isSigner: false, isWritable: false },
-
     { pubkey: memory, isSigner: false, isWritable: false },
-
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
   ];

--- a/src/models/lending/market.ts
+++ b/src/models/lending/market.ts
@@ -45,5 +45,10 @@ export const LendingMarketParser = (
   return details;
 };
 
-// TODO:
-// create instructions for init
+// TODO: create instructions for init
+/// Initializes a new lending market.
+///
+///   0. `[writable]` Lending market account.
+///   1. `[]` Quote currency SPL Token mint. Must be initialized.
+///   2. `[]` Rent sysvar
+///   3. '[]` Token program id

--- a/src/models/lending/obligation.ts
+++ b/src/models/lending/obligation.ts
@@ -69,6 +69,19 @@ export const healthFactorToRiskColor = (health: number) => {
   return "";
 };
 
+/// Initializes a new loan obligation.
+///
+///   0. `[]` Deposit reserve account.
+///   1. `[]` Borrow reserve account.
+///   2. `[writable]` Obligation
+///   3. `[writable]` Obligation token mint
+///   4. `[writable]` Obligation token output
+///   5. `[]` Obligation token owner
+///   6. `[]` Lending market account.
+///   7. `[]` Derived lending market authority.
+///   8. `[]` Clock sysvar
+///   9. `[]` Rent sysvar
+///   10 '[]` Token program id
 export const initObligationInstruction = (
   depositReserve: PublicKey,
   borrowReserve: PublicKey,

--- a/src/models/lending/obligation.ts
+++ b/src/models/lending/obligation.ts
@@ -90,7 +90,7 @@ export const initObligationInstruction = (
   obligationTokenOutput: PublicKey,
   obligationTokenOwner: PublicKey,
   lendingMarket: PublicKey,
-  lendingMarketAuthority: PublicKey
+  lendingMarketAuthority: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([BufferLayout.u8("instruction")]);
 
@@ -109,10 +109,8 @@ export const initObligationInstruction = (
     { pubkey: obligationMint, isSigner: false, isWritable: true },
     { pubkey: obligationTokenOutput, isSigner: false, isWritable: true },
     { pubkey: obligationTokenOwner, isSigner: false, isWritable: false },
-
     { pubkey: lendingMarket, isSigner: false, isWritable: false },
     { pubkey: lendingMarketAuthority, isSigner: false, isWritable: false },
-
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },

--- a/src/models/lending/repay.ts
+++ b/src/models/lending/repay.ts
@@ -29,8 +29,8 @@ import { TOKEN_PROGRAM_ID, LENDING_PROGRAM_ID } from "../../utils/ids";
 ///   13 `[]` Token program id
 export const repayInstruction = (
   liquidityAmount: number | BN,
-  from: PublicKey, // Liquidity input SPL Token account. $authority can transfer $liquidity_amount
-  to: PublicKey, // Collateral output SPL Token account,
+  from: PublicKey,
+  to: PublicKey,
   repayReserveAccount: PublicKey,
   repayReserveLiquiditySupply: PublicKey,
   withdrawReserve: PublicKey,
@@ -40,7 +40,7 @@ export const repayInstruction = (
   obligationInput: PublicKey,
   lendingMarket: PublicKey,
   authority: PublicKey,
-  transferAuthority: PublicKey
+  transferAuthority: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),
@@ -59,25 +59,20 @@ export const repayInstruction = (
   const keys = [
     { pubkey: from, isSigner: false, isWritable: true },
     { pubkey: to, isSigner: false, isWritable: true },
-
     { pubkey: repayReserveAccount, isSigner: false, isWritable: true },
     { pubkey: repayReserveLiquiditySupply, isSigner: false, isWritable: true },
-
     { pubkey: withdrawReserve, isSigner: false, isWritable: false },
     {
       pubkey: withdrawReserveCollateralSupply,
       isSigner: false,
       isWritable: true,
     },
-
     { pubkey: obligation, isSigner: false, isWritable: true },
     { pubkey: obligationMint, isSigner: false, isWritable: true },
     { pubkey: obligationInput, isSigner: false, isWritable: true },
-
     { pubkey: lendingMarket, isSigner: false, isWritable: false },
     { pubkey: authority, isSigner: false, isWritable: false },
     { pubkey: transferAuthority, isSigner: true, isWritable: false },
-
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
   ];

--- a/src/models/lending/reserve.ts
+++ b/src/models/lending/reserve.ts
@@ -181,8 +181,7 @@ export const initReserveInstruction = (
   lendingMarket: PublicKey,
   lendingMarketAuthority: PublicKey,
   transferAuthority: PublicKey,
-
-  dexMarket: PublicKey // TODO: optional
+  dexMarket?: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),
@@ -216,10 +215,12 @@ export const initReserveInstruction = (
     { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
-
-    // optionals
-    { pubkey: dexMarket, isSigner: false, isWritable: false },
   ];
+
+  if (dexMarket) {
+    keys.push({ pubkey: dexMarket, isSigner: false, isWritable: false });
+  }
+
   return new TransactionInstruction({
     keys,
     programId: LENDING_PROGRAM_ID,

--- a/src/models/lending/reserve.ts
+++ b/src/models/lending/reserve.ts
@@ -146,6 +146,26 @@ export const LendingReserveParser = (
   return details;
 };
 
+/// Initializes a new lending market reserve.
+///
+///   0. `[writable]` Source liquidity token account.  $authority can transfer $liquidity_amount
+///   1. `[writable]` Destination collateral token account - uninitialized
+///   2. `[writable]` Reserve account.
+///   3. `[]` Reserve liquidity SPL Token mint
+///   4. `[writable]` Reserve liquidity supply SPL Token account - uninitialized
+///   5. `[writable]` Reserve collateral SPL Token mint - uninitialized
+///   6. `[writable]` Reserve collateral token supply - uninitialized
+///   7. `[writable]` Reserve collateral fees receiver - uninitialized.
+///                     Owner will be set to the lending market account.
+///   8. `[]` Lending market account.
+///   9. `[signer]` Lending market owner.
+///   10 `[]` Derived lending market authority.
+///   11 `[]` User transfer authority ($authority).
+///   12 `[]` Clock sysvar
+///   13 `[]` Rent sysvar
+///   14 '[]` Token program id
+///   15 `[optional]` Serum DEX market account. Not required for quote currency reserves.
+///                     Must be initialized and match quote and base currency.
 export const initReserveInstruction = (
   liquidityAmount: number | BN,
   maxUtilizationRate: number,
@@ -207,6 +227,11 @@ export const initReserveInstruction = (
   });
 };
 
+/// Accrue interest on reserves
+///
+///   0. `[]` Clock sysvar
+///   1. `[writable]` Reserve account.
+///   .. `[writable]` Additional reserve accounts.
 export const accrueInterestInstruction = (
   ...reserveAccount: PublicKey[]
 ): TransactionInstruction => {

--- a/src/models/lending/reserve.ts
+++ b/src/models/lending/reserve.ts
@@ -169,10 +169,8 @@ export const LendingReserveParser = (
 export const initReserveInstruction = (
   liquidityAmount: number | BN,
   maxUtilizationRate: number,
-
-  from: PublicKey, // Liquidity input SPL Token account. $authority can transfer $liquidity_amount
-  to: PublicKey, // Collateral output SPL Token account,
-
+  from: PublicKey,
+  to: PublicKey,
   reserveAccount: PublicKey,
   liquidityMint: PublicKey,
   liquiditySupply: PublicKey,
@@ -192,7 +190,7 @@ export const initReserveInstruction = (
   const data = Buffer.alloc(dataLayout.span);
   dataLayout.encode(
     {
-      instruction: LendingInstruction.InitReserve, // Init reserve instruction
+      instruction: LendingInstruction.InitReserve,
       liquidityAmount: new BN(liquidityAmount),
       maxUtilizationRate: maxUtilizationRate,
     },
@@ -207,7 +205,6 @@ export const initReserveInstruction = (
     { pubkey: liquiditySupply, isSigner: false, isWritable: true },
     { pubkey: collateralMint, isSigner: false, isWritable: true },
     { pubkey: collateralSupply, isSigner: false, isWritable: true },
-
     // NOTE: Why lending market needs to be a signer?
     { pubkey: lendingMarket, isSigner: true, isWritable: true },
     { pubkey: lendingMarketAuthority, isSigner: false, isWritable: false },

--- a/src/models/lending/reserve.ts
+++ b/src/models/lending/reserve.ts
@@ -168,6 +168,7 @@ export const LendingReserveParser = (
 ///                     Must be initialized and match quote and base currency.
 export const initReserveInstruction = (
   liquidityAmount: number | BN,
+  // NOTE: InitReserve accepts ReserveConfig as second arg
   maxUtilizationRate: number,
   from: PublicKey,
   to: PublicKey,

--- a/src/models/lending/withdraw.ts
+++ b/src/models/lending/withdraw.ts
@@ -9,6 +9,18 @@ import { TOKEN_PROGRAM_ID, LENDING_PROGRAM_ID } from "../../utils/ids";
 import * as Layout from "./../../utils/layout";
 import { LendingInstruction } from "./lending";
 
+/// Withdraw tokens from a reserve. The input is a collateral token representing ownership
+/// of the reserve liquidity pool.
+///
+///   0. `[writable]` Source collateral token account. $authority can transfer $collateral_amount
+///   1. `[writable]` Destination liquidity token account.
+///   2. `[writable]` Reserve account.
+///   3. `[writable]` Reserve collateral SPL Token mint.
+///   4. `[writable]` Reserve liquidity supply SPL Token account.
+///   5. `[]` Lending market account.
+///   6. `[]` Derived lending market authority.
+///   7. `[]` User transfer authority ($authority).
+///   8. '[]` Token program id
 export const withdrawInstruction = (
   collateralAmount: number | BN,
   from: PublicKey, // Collateral input SPL Token account. $authority can transfer $liquidity_amount

--- a/src/models/lending/withdraw.ts
+++ b/src/models/lending/withdraw.ts
@@ -23,14 +23,14 @@ import { LendingInstruction } from "./lending";
 ///   8. '[]` Token program id
 export const withdrawInstruction = (
   collateralAmount: number | BN,
-  from: PublicKey, // Collateral input SPL Token account. $authority can transfer $liquidity_amount
-  to: PublicKey, // Liquidity output SPL Token account,
+  from: PublicKey,
+  to: PublicKey,
   reserveAccount: PublicKey,
   collateralMint: PublicKey,
   reserveSupply: PublicKey,
   lendingMarket: PublicKey,
   authority: PublicKey,
-  transferAuthority: PublicKey
+  transferAuthority: PublicKey,
 ): TransactionInstruction => {
   const dataLayout = BufferLayout.struct([
     BufferLayout.u8("instruction"),


### PR DESCRIPTION
This PR

1. (breaking) Changes the parameter order of `depositInstruction` to match the `DepositReserveLiquidity` SPL instruction
2. Updates the inline instruction docs to those in SPL
3. Makes the last argument of `initReserveInstruction` optional as in SPL
4. Performs some minor related cleanup